### PR TITLE
Better Spell Sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ and then install using this link: [backpack.tf extended sorting.user.js](https:/
 
 _____________________________________________
 
+#### 0.1.22
+
+Added:
+
+* Double spell grouping
+* Choosing group by spells groups by colors then by footprints. Group by spell again to inverse. 
+
+Fixed:
+
+* Voices from Below sorting
+
 #### 0.1.21
 
 Added:

--- a/backpack.tf extended sorting.meta.js
+++ b/backpack.tf extended sorting.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         backpack.tf - Miscellaneous Extensions
 // @description  Adds more options for sorting items in backpacks (currently Sorting for paints, spells, levels, scm price, classified listings) and other stuff which I would have liked (including highlighting spells, autocompleting spell names, autocompleting particle names or sorting unusuals by class)
-// @version      0.1.21
+// @version      0.1.22
 // @author       Netroscript
 // @namespace    https://github.com/NetroScript
 // @include      /^https?:\/\/backpack\.tf\/.*


### PR DESCRIPTION
Fix Voices from below detection.
Normalize spell sorting and add alternative sort.
The first spell sort always sorts by color effect first and the alt always sorts by footprints first.