### PR TITLE
Fix incorrect classifieds queries on paintkit items

### DIFF
--- a/backpack.tf extended sorting.user.js
+++ b/backpack.tf extended sorting.user.js
@@ -1192,7 +1192,7 @@ class</a></li>
 	});
 
 	//Modify Popover
-	$("body").on("mouseover", ".item, .item-icon", function () {
+	$("body").on("mouseover", ".item", function () {
 		let self = this;
 		let id = setInterval(function () {
 
@@ -1212,8 +1212,6 @@ class</a></li>
                             if (popover.find("a[href^='/premium/search']").length !== 1) {
                                 popover.append("<a class=\"btn btn-default btn-xs\" href=\"" + genWeaponSearch($(self)[0], "/premium/search?") + "\"><i class=\"fa fa-star\"></i>Skin Search</a>");    
                             }
-                            //popover.append("<a class=\"btn btn-default btn-xs\" href=\"" + genWeaponSearch($(self)[0], "/premium/search?") + "\"><i class=\"fa fa-star\"></i>Skin Search</a>");    popover.append("<a class=\"btn btn-default btn-xs\" href=\"" + genWeaponSearch($(self)[0], "/premium/search?") + "\"><i class=\"fa fa-star\"></i>Skin Search</a>");
-                            console.log(popover);
                             setTimeout(()=>popover.parent().find('#popover-search-links > a').first()[0].href = genWeaponSearch($(self)[0], "/classifieds?"), 100);
                         }
 						

--- a/backpack.tf extended sorting.user.js
+++ b/backpack.tf extended sorting.user.js
@@ -1149,6 +1149,9 @@ class</a></li>
 		if (elQuality) {
 			query += "&elevated=" + elQuality;
 		}
+
+        console.log(query);
+
 		return query;
 	}
 
@@ -1189,7 +1192,7 @@ class</a></li>
 	});
 
 	//Modify Popover
-	$("body").on("mouseover", ".item", function () {
+	$("body").on("mouseover", ".item, .item-icon", function () {
 		let self = this;
 		let id = setInterval(function () {
 
@@ -1207,10 +1210,11 @@ class</a></li>
 						}
                         if($(self).attr("data-paint_kit")){
                             if (popover.find("a[href^='/premium/search']").length !== 1) {
-                                popover.append("<a class=\"btn btn-default btn-xs\" href=\"" + genWeaponSearch($(self)[0], "/premium/search?") + "\"><i class=\"fa fa-star\"></i>Skin Search</a>");
+                                popover.append("<a class=\"btn btn-default btn-xs\" href=\"" + genWeaponSearch($(self)[0], "/premium/search?") + "\"><i class=\"fa fa-star\"></i>Skin Search</a>");    
                             }
-                            
-                            popover.find('.popover-search-links > a:').first().attr('href', genWeaponSearch($(self)[0], "/classifieds?"));
+                            //popover.append("<a class=\"btn btn-default btn-xs\" href=\"" + genWeaponSearch($(self)[0], "/premium/search?") + "\"><i class=\"fa fa-star\"></i>Skin Search</a>");    popover.append("<a class=\"btn btn-default btn-xs\" href=\"" + genWeaponSearch($(self)[0], "/premium/search?") + "\"><i class=\"fa fa-star\"></i>Skin Search</a>");
+                            console.log(popover);
+                            setTimeout(()=>popover.parent().find('#popover-search-links > a').first()[0].href = genWeaponSearch($(self)[0], "/classifieds?"), 100);
                         }
 						
 

--- a/backpack.tf extended sorting.user.js
+++ b/backpack.tf extended sorting.user.js
@@ -1131,8 +1131,7 @@ class</a></li>
 		return query;
 	}
 
-	function genWeaponSearch(element) {
-		let query = "/premium/search?";
+	function genWeaponSearch(element, query) {
 		let item = $(element);
 		let name = item.attr("data-base_name");
 		let quality = item.attr("data-quality");
@@ -1206,9 +1205,14 @@ class</a></li>
 						if (popover.find("a[href^='https://marketplace.tf']").length !== 1 && popover.find(".cmpb").length < 1) {
 							popover.append("<a class=\"btn btn-default btn-xs cmpb\" href=\"" + genMP($(self)[0]) + "\" target=\"_blank\"><img src=\"/images/marketplace-small.png?v=2\" style='width: 13px;height: 13px;margin-top: -4px;'> Marketplace</a>");
 						}
-						if (popover.find("a[href^='/premium/search']").length !== 1 && $(self).attr("data-paint_kit")) {
-							popover.append("<a class=\"btn btn-default btn-xs\" href=\"" + genWeaponSearch($(self)[0]) + "\"><i class=\"fa fa-star\"></i>Skin Search</a>");
-						}
+                        if($(self).attr("data-paint_kit")){
+                            if (popover.find("a[href^='/premium/search']").length !== 1) {
+                                popover.append("<a class=\"btn btn-default btn-xs\" href=\"" + genWeaponSearch($(self)[0], "/premium/search?") + "\"><i class=\"fa fa-star\"></i>Skin Search</a>");
+                            }
+                            
+                            popover.find('.popover-search-links > a:').first().attr('href', genWeaponSearch($(self)[0], "/classifieds?"));
+                        }
+						
 
 						clearInterval(id2);
 					}

--- a/backpack.tf extended sorting.user.js
+++ b/backpack.tf extended sorting.user.js
@@ -1149,9 +1149,6 @@ class</a></li>
 		if (elQuality) {
 			query += "&elevated=" + elQuality;
 		}
-
-        console.log(query);
-
 		return query;
 	}
 


### PR DESCRIPTION
Backpack tf has an issue where skins/paintkit items parse into the wrong url in the popover classifieds link.
This fixes the issue by using the skin search url generator and replacing the classifieds link

Backpack version:
https://backpack.tf/classifieds?item=Autumn%20|%20Shotgun%20(Factory%20New)&quality=11&tradable=1&craftable=1&australium=-1&killstreak_tier=0

Correct:
https://backpack.tf/classifieds?item=Shotgun&quality=11&texture_name=Autumn&wear_tier=1&killstreak_tier=0

